### PR TITLE
arg_parse.c: Support multiple files conversion

### DIFF
--- a/include/arg_parse.h
+++ b/include/arg_parse.h
@@ -8,7 +8,7 @@
 
 #include "options.h"
 
-#define STR_EQUAL 0
+// #define STR_EQUAL 0      // deprecated
 
 #define VERSION "v0.2.0"
 
@@ -60,12 +60,13 @@ Examples:                                                                   \n\
 "
 
 
-typedef struct _FileJob {
-    char * path;
-    struct _FileJob * nextJob;
+typedef struct FileJob {
+    char * file_path;
+    ImageOptions * file_opts;
+    struct FileJob * next_job;
 } FileJob;
 
-FileJob * arg_parse(int argc, char ** argv, ImageOptions * opts);
+FileJob * arg_parse(int argc, char ** argv);
 
 void free_job_memory(FileJob * job_list);
 

--- a/src/main.c
+++ b/src/main.c
@@ -146,24 +146,15 @@ int main(int argc, char ** argv) {
     printf("[DEBUG] ASCII Brightness levels: %d\n", brightness_levels);
 #endif
 
-    // Default options
-    ImageOptions opts = {
-        .output_mode = ANSI,
-        .original_size = false,
-        .true_color = true,
-        .squashing_enabled = true,
-        .suppress_header = false
-    };
-
-    FileJob * jobs = arg_parse(argc, argv, &opts);
-    if (jobs == NULL) return EXIT_FAILURE;
+    FileJob * jobs = arg_parse(argc, argv);
+    if (jobs == NULL)
+        return EXIT_FAILURE;
 
     // Parse file paths and do all jobs.
-    for (FileJob * read_jobs = jobs; read_jobs != NULL; read_jobs = read_jobs->nextJob) {    
-        int r = read_and_convert(read_jobs->path, &opts);
-        if (r == -1) {
-            fprintf(stderr, "Failed to convert image: %s\n", read_jobs->path);
-        }
+    for (FileJob * fj_iter = jobs; fj_iter != NULL; fj_iter = fj_iter->next_job) {    
+        int ret = read_and_convert(fj_iter->file_path, fj_iter->file_opts);
+        if (ret == -1)
+            fprintf(stderr, "Failed to convert image: %s\n", fj_iter->file_path);
         printf("\n");
     }
 


### PR DESCRIPTION
This is for #1.

Now we can apply different options for multiple files.
In details, no given option means that we let this file have a default option.

Finally, the option `--` is deleted as I mentioned to you.