### PR TITLE
arg_parse.c: Keep print sequences as command gives

### DIFF
--- a/include/arg_parse.h
+++ b/include/arg_parse.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 
 #include "options.h"
+#include "list.h"
 
 #define VERSION "v0.3.0"
 
@@ -58,14 +59,13 @@ Examples:                                                                   \n\
 "
 
 
-typedef struct FileJob {
+struct FileJob {
     char * file_path;
-    ImageOptions * file_opts;
-    struct FileJob * next_job;
-} FileJob;
+    struct ImageOptions * file_opts;
+    struct list_node list;
+};
 
-FileJob * arg_parse(int argc, char ** argv);
-
-void free_job_memory(FileJob * job_list);
+void free_job_memory(struct list_node * job_list);
+int arg_parse(int argc, char ** argv, struct list_node * jobs);
 
 #endif  /* ARG_H */

--- a/include/errno.h
+++ b/include/errno.h
@@ -1,0 +1,6 @@
+#ifndef ERRNO_H
+#define ERRNO_H
+
+#define ENULLPTR    0
+
+#endif  /* ERRNO_H */

--- a/include/list.h
+++ b/include/list.h
@@ -1,0 +1,40 @@
+#ifndef LIST_H
+#define LIST_H
+
+#include "errno.h"
+
+/**
+ * Singly linked list implementation.
+ * 
+ * This list do caching the last list node
+ * for O(1) performance when a new node is added.
+ */
+
+#define LIST_HEAD(name) \
+        struct list_node name = { &(name), &(name) }
+
+struct list_node {
+    struct list_node *next, *last;
+};
+
+static inline uint list_add(struct list_node *head,
+                            struct list_node *new_node)
+{
+    if (!head) {
+        fprintf(stderr, "%s: head pointer not initialized!\n\n", __func__);
+        return -ENULLPTR;
+    }
+
+    head->last->next = new_node;
+    head->last = new_node;
+    return 0;
+}
+
+#define container_of(ptr, type, member) ({                  \
+        void *_ptr = (void *)(ptr);                         \
+        ((type *)(_ptr - (size_t)&((type *)0)->member)); })
+
+#define list_for_each(pos, head) \
+	for (pos = (head)->next; pos; pos = pos->next)
+
+#endif

--- a/include/options.h
+++ b/include/options.h
@@ -13,7 +13,7 @@
 enum OutputModes {OUTPUT_MODES(GENERATE_ENUM)};
 static const char * OutputModeStr[] = {OUTPUT_MODES(GENERATE_STRING)}; // Strings used for output.
 
-typedef struct {
+struct ImageOptions{
     unsigned int width;
     unsigned int height;
 
@@ -23,6 +23,6 @@ typedef struct {
     bool true_color;
     bool squashing_enabled;
     bool suppress_header;
-} ImageOptions;
+};
 
 #endif  /* OPTIONS_H */


### PR DESCRIPTION
Hi again, @danny-burrows!

I've implemented the feature that supports multiple-file conversion at #1,
but I discovered that the results of conversions were printed **in reverse order**.

To fix this problem, I add `a singly linked list with caching a last node`, and apply it to the arg_parse() function.
(Of course, this affects other relative files.)

There are a few(?) changes for this PR. Please check this out.

Thanks to read.